### PR TITLE
Added flask config option to turn on/off compare types.

### DIFF
--- a/flask_migrate/templates/flask/env.py
+++ b/flask_migrate/templates/flask/env.py
@@ -55,9 +55,16 @@ def run_migrations_online():
                 poolclass=pool.NullPool)
 
     connection = engine.connect()
+
+    compare_type = False
+
+    if 'MIGRATION_COMPARE_TYPE' in current_app.config:
+        compare_type = current_app.config['MIGRATION_COMPARE_TYPE']
+
     context.configure(
                 connection=connection,
-                target_metadata=target_metadata
+                target_metadata=target_metadata,
+                compare_type=compare_type
                 )
 
     try:


### PR DESCRIPTION
Added config value `MIGRATION_COMPARE_TYPE` which when set to `True` will turn on `compare_type` in `run_migrations_online()`, which will allow you to compare if db column types have changes. 