### PR TITLE
Make default directory relative to flask app root path

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -30,9 +30,12 @@ class Config(AlembicConfig):
         package_dir = os.path.abspath(os.path.dirname(__file__))
         return os.path.join(package_dir, 'templates')
 
+def _get_default_directory():
+    return os.path.join(current_app.root_path, current_app.extensions['migrate'].directory)
+
 def _get_config(directory):
     if directory is None:
-        directory = os.path.join(current_app.root_path, current_app.extensions['migrate'].directory)
+        directory = _get_default_directory()
     config = Config(os.path.join(directory, 'alembic.ini'))
     config.set_main_option('script_location', directory)
     return config
@@ -42,7 +45,11 @@ MigrateCommand = Manager(usage = 'Perform database migrations')
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "migration script directory (default is 'migrations')")
 def init(directory = None):
     "Generates a new migration"
-    config = _get_config(directory)
+    if directory is None:
+        directory = _get_default_directory()
+    config = Config()
+    config.set_main_option('script_location', directory)
+    config.config_file_name = os.path.join(directory, 'alembic.ini')
     command.init(config, directory, 'flask')
 
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "Migration script directory (default is 'migrations')")

--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -32,7 +32,7 @@ class Config(AlembicConfig):
 
 def _get_config(directory):
     if directory is None:
-        directory = current_app.extensions['migrate'].directory
+        directory = os.path.join(current_app.root_path, current_app.extensions['migrate'].directory)
     config = Config(os.path.join(directory, 'alembic.ini'))
     config.set_main_option('script_location', directory)
     return config
@@ -42,11 +42,7 @@ MigrateCommand = Manager(usage = 'Perform database migrations')
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "migration script directory (default is 'migrations')")
 def init(directory = None):
     "Generates a new migration"
-    if directory is None:
-        directory = current_app.extensions['migrate'].directory
-    config = Config()
-    config.set_main_option('script_location', directory)
-    config.config_file_name = os.path.join(directory, 'alembic.ini')
+    config = _get_config(directory)
     command.init(config, directory, 'flask')
 
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "Migration script directory (default is 'migrations')")


### PR DESCRIPTION
Before this change, the directory was always set to 'migrations' in the default case. This makes it dependent on the current working directory of any command being ran. The change uses current_app.root_path to make the default directory relative to the flask app it is for.

Additionally it uses _get_config for the init command, the utility function already used for the other functions (no behaviour change).