### PR TITLE
adding compare type with init

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -40,7 +40,7 @@ def _get_config(directory):
 MigrateCommand = Manager(usage = 'Perform database migrations')
 
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "migration script directory (default is 'migrations')")
-@MigrateCommand.option('--compare_type', dest = 'compare_type', action = 'store_true', default = False, help = "Indicates type comparison behavior during an autogenerate operation. Defaults to False which disables type comparison. Set to True to turn on default type comparison, which has varied accuracy depending on backend.")
+@MigrateCommand.option('-c','--compare_type', dest = 'compare_type', action = 'store_true', default = False, help = "Indicates type comparison behavior during an autogenerate operation. Defaults to False which disables type comparison. Set to True to turn on default type comparison, which has varied accuracy depending on backend.")
 def init(directory = None, compare_type=False):
     "Generates a new migration"
     if directory is None:

--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -40,12 +40,14 @@ def _get_config(directory):
 MigrateCommand = Manager(usage = 'Perform database migrations')
 
 @MigrateCommand.option('-d', '--directory', dest = 'directory', default = None, help = "migration script directory (default is 'migrations')")
-def init(directory = None):
+@MigrateCommand.option('--compare_type', dest = 'compare_type', action = 'store_true', default = False, help = "Indicates type comparison behavior during an autogenerate operation. Defaults to False which disables type comparison. Set to True to turn on default type comparison, which has varied accuracy depending on backend.")
+def init(directory = None, compare_type=False):
     "Generates a new migration"
     if directory is None:
         directory = current_app.extensions['migrate'].directory
     config = Config()
     config.set_main_option('script_location', directory)
+    config.set_main_option('compare_type',compare_type)
     config.config_file_name = os.path.join(directory, 'alembic.ini')
     command.init(config, directory, 'flask')
 

--- a/flask_migrate/templates/flask/env.py
+++ b/flask_migrate/templates/flask/env.py
@@ -57,7 +57,8 @@ def run_migrations_online():
     connection = engine.connect()
     context.configure(
                 connection=connection,
-                target_metadata=target_metadata
+                target_metadata=target_metadata,
+                compare_type=config.get_main_option("compare_type")
                 )
 
     try:


### PR DESCRIPTION
I added the ability to add the config for compare_types via init. I did not have time to test that this actually works. I'll make a new project and see if this works. 
Nice job on Flask-Migrate btw. It has been a tremendous help to me.  