### PR TITLE
Update __init__.py

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -6,7 +6,7 @@ from alembic.config import Config as AlembicConfig
 from alembic import command
 
 
-alembic_version = tuple([int(v) for v in __alembic_version__.split('.')])
+alembic_version = tuple([int(v) for v in __alembic_version__.split('.') if isinstance(v, int)])
 
 
 class _MigrateConfig(object):


### PR DESCRIPTION
alembic __version__ now includes parts that are not integers (e.g., 0.7.5.post1). This change will prevent the code from trying to convert non-integer values to integers.