### PR TITLE
Add sane default for `db downgrade --sql`

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -205,6 +205,8 @@ def upgrade(directory=None, revision='head', sql=False, tag=None, x_arg=None):
 def downgrade(directory=None, revision='-1', sql=False, tag=None, x_arg=None):
     """Revert to a previous version"""
     config = _get_config(directory, x_arg=x_arg)
+    if sql and revision == '-1':
+        revision = 'head:-1'
     command.downgrade(config, revision, sql=sql, tag=tag)
 
 


### PR DESCRIPTION
When doing an offline migration, ie `db downgrade --sql`, the command will fail with the following error: `alembic.util.CommandError: downgrade with --sql requires <fromrev>:<torev>`. This patch sets the default to `head:-1`, which is the expected input to the command library.

Also as a side note, your Mega-Tutorial for Flask has helped me out more than once. Thanks for all your work. 