### PR TITLE
Fix the merge command by allowing more than one argument.

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -159,7 +159,7 @@ def migrate(directory=None, message=None, sql=False, head='head', splice=False,
                        help=('Specify a branch label to apply to the new '
                              'revision'))
 @MigrateCommand.option('-m', '--message', dest='message', default=None)
-@MigrateCommand.option('revisions',
+@MigrateCommand.option('revisions', nargs='+',
                        help='one or more revisions, or "heads" for all heads')
 @MigrateCommand.option('-d', '--directory', dest='directory', default=None,
                        help=("migration script directory (default is "


### PR DESCRIPTION
If you try to use manage.py like this:
`python manage.py db merge 123abc 456def`
You get:
`manage.py: error: too many arguments`
This change allows multiple arguments for the merge command.