### PR TITLE
Update the way to import the flask extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This is an example application that handles database migrations through Flask-Mi
 
 ```python
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.script import Manager
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_sqlalchemy import SQLAlchemy
+from flask_script import Manager
+from flask_migrate import Migrate, MigrateCommand
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,9 +21,9 @@ Example
 This is an example application that handles database migrations through Flask-Migrate::
 
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
-    from flask.ext.script import Manager
-    from flask.ext.migrate import Migrate, MigrateCommand
+    from flask_sqlalchemy import SQLAlchemy
+    from flask_script import Manager
+    from flask_migrate import Migrate, MigrateCommand
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
@@ -95,7 +95,7 @@ Command Reference
 
 Flask-Migrate exposes two objects, ``Migrate`` and ``MigrateCommand``. The former is used to initialize the extension, while the latter is a ``Manager`` instance that needs to be registered with Flask-Script to expose the extension's command line options::
 
-    from flask.ext.migrate import Migrate, MigrateCommand
+    from flask_migrate import Migrate, MigrateCommand
     migrate = Migrate(app, db)
     manager.add_command('db', MigrateCommand)
 
@@ -156,7 +156,7 @@ Notes:
 API Reference
 -------------
 
-The commands exposed by Flask-Migrate's interface to Flask-Script can also be accessed programmatically by importing the functions from module ``flask.ext.migrate``. The available functions are:
+The commands exposed by Flask-Migrate's interface to Flask-Script can also be accessed programmatically by importing the functions from module ``flask_migrate``. The available functions are:
 
 - ``init(directory='migrations', multidb=False)``
     Initializes migration support for the application.

--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -1,7 +1,7 @@
 import os
 import argparse
 from flask import current_app
-from flask.ext.script import Manager
+from flask_script import Manager
 from alembic import __version__ as __alembic_version__
 from alembic.config import Config as AlembicConfig
 from alembic import command


### PR DESCRIPTION
The old way `flask.ext.xxx` will be deprecated in flask 1.0, and since the extensions that `flask-migrate` use support the modern way, I think we'd better keep it up to date. Also I found that the tests are using the proper way to import the extensions, so I guess we can support it now.