### PR TITLE
Allow to init_app correctly without specifying db.

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -45,7 +45,7 @@ class Migrate(object):
         self.directory = directory or self.directory
         if not hasattr(app, 'extensions'):
             app.extensions = {}
-        app.extensions['migrate'] = _MigrateConfig(self, db, **kwargs)
+        app.extensions['migrate'] = _MigrateConfig(self, self.db, **kwargs)
 
     def configure(self, f):
         self.configure_callbacks.append(f)


### PR DESCRIPTION
When using app factory like this:
```
db = SQLAlchemy()
migrate = Migrate(db=db)

def create_app():
    pp = Flask(__name__)
    db.init_app(app)
    migrate.init_app(app)
```
I've go the next error:

```
...
  File "migrations/env.py", line 23, in <module>
    target_metadata = current_app.extensions['migrate'].db.metadata
AttributeError: 'NoneType' object has no attribute 'metadata'
```
