### PR TITLE
Fix typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to Flask-Migrate's documentation!
 ==========================================
 
-**Flask-Migrate** is an extension that handles SQLAlchemy database migrations for Flask applications using Alembic. The database operations are made available through the Flask comamnd-line interface or through the Flask-Script extension.
+**Flask-Migrate** is an extension that handles SQLAlchemy database migrations for Flask applications using Alembic. The database operations are made available through the Flask command-line interface or through the Flask-Script extension.
 
 Installation
 ------------


### PR DESCRIPTION
Just a single word typo, but seeing it happen right at the top of the [Flask-Migrate](https://flask-migrate.readthedocs.io/en/latest/) page was slightly bothersome.