### PR TITLE
Imports at top of file as specified by Flake8 and added branch label.

### DIFF
--- a/flask_migrate/templates/flask-multidb/script.py.mako
+++ b/flask_migrate/templates/flask-multidb/script.py.mako
@@ -8,6 +8,9 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
@@ -15,9 +18,6 @@ down_revision = ${repr(down_revision)}
 branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade(engine_name):
     globals()["upgrade_%s" % engine_name]()

--- a/flask_migrate/templates/flask/script.py.mako
+++ b/flask_migrate/templates/flask/script.py.mako
@@ -1,18 +1,20 @@
 """${message}
 
 Revision ID: ${up_revision}
-Revises: ${down_revision}
+Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
     ${upgrades if upgrades else "pass"}


### PR DESCRIPTION
Moving the imports to the top of the file will prevent an error:
'E402 module level import not at top of file'.

This has been fixed in the alembic templates, however these are not used in Flask-Migrate