### PR TITLE
support passing alembic context kwargs to constructor with app factory pattern

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -37,6 +37,7 @@ class Migrate(object):
         self.configure_callbacks = []
         self.db = db
         self.directory = directory
+        self.alembic_ctx_kwargs = kwargs
         if app is not None and db is not None:
             self.init_app(app, db, directory, **kwargs)
 
@@ -45,7 +46,8 @@ class Migrate(object):
         self.directory = directory or self.directory
         if not hasattr(app, 'extensions'):
             app.extensions = {}
-        app.extensions['migrate'] = _MigrateConfig(self, self.db, **kwargs)
+        app.extensions['migrate'] = _MigrateConfig(self, self.db,
+            **(kwargs if kwargs else self.alembic_ctx_kwargs))
 
     def configure(self, f):
         self.configure_callbacks.append(f)


### PR DESCRIPTION
I'm using the application factory pattern in my app, so what I would like to be able to do is something like the following:
```python
# backend/extensions.py
db = SQLAlchemy()
migrate = Migrate(db=db, render_as_batch=True)

# backend/app.py
def register_extensions(app):
    for extension in get_extensions():
        extension.init_app(app)
```

As it stands however, this isn't supported; the `render_as_batch` option will be forgotten, unlike the `db` and `directory` args. Conceptually I find it more natural to add the kwargs in the constructor instead of to `init_app` - as I understand it `init_app` is just attaching the app to the extension rather than for further configuring of the extension?