### PR TITLE
Add indicate-current option into history command

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -297,6 +297,8 @@ def show(directory=None, revision='head'):
         raise RuntimeError('Alembic 0.7.0 or greater is required')
 
 
+@MigrateCommand.option('-i', '--indicate-current', dest='indicate_current', action='store_true',
+                       default=False, help='Indicate current version (Alembic 0.9.9 or greater is required)')
 @MigrateCommand.option('-v', '--verbose', dest='verbose', action='store_true',
                        default=False, help='Use more verbose output')
 @MigrateCommand.option('-r', '--rev-range', dest='rev_range', default=None,
@@ -304,10 +306,12 @@ def show(directory=None, revision='head'):
 @MigrateCommand.option('-d', '--directory', dest='directory', default=None,
                        help=("migration script directory (default is "
                              "'migrations')"))
-def history(directory=None, rev_range=None, verbose=False):
+def history(directory=None, rev_range=None, verbose=False, indicate_current=False):
     """List changeset scripts in chronological order."""
     config = current_app.extensions['migrate'].migrate.get_config(directory)
-    if alembic_version >= (0, 7, 0):
+    if alembic_version >= (0, 9, 9):
+        command.history(config, rev_range, verbose=verbose, indicate_current=indicate_current)
+    elif alembic_version >= (0, 7, 0):
         command.history(config, rev_range, verbose=verbose)
     else:
         command.history(config, rev_range)

--- a/flask_migrate/cli.py
+++ b/flask_migrate/cli.py
@@ -168,10 +168,11 @@ def show(directory, revision):
 @click.option('-r', '--rev-range', default=None,
               help='Specify a revision range; format is [start]:[end]')
 @click.option('-v', '--verbose', is_flag=True, help='Use more verbose output')
+@click.option('-i', '--indicate-current', is_flag=True, help='Indicate current version (Alembic 0.9.9 or greater is required)')
 @with_appcontext
-def history(directory, rev_range, verbose):
+def history(directory, rev_range, verbose, indicate_current):
     """List changeset scripts in chronological order."""
-    _history(directory, rev_range, verbose)
+    _history(directory, rev_range, verbose, indicate_current)
 
 
 @db.command()


### PR DESCRIPTION
This PR is aimed to add `-i/--indicate-current` option into `history` command.
This option indicates current version in a result of history command.
The requirement is [Alembic version 0.9.9](http://alembic.zzzcomputing.com/en/latest/changelog.html#change-0.9.9) or greater.

*  with `--help`
```
$ FLASK_APP=app.py flask db history --help
Usage: flask db history [OPTIONS]

  List changeset scripts in chronological order.

Options:
  -d, --directory TEXT    migration script directory (default is "migrations")
  -r, --rev-range TEXT    Specify a revision range; format is [start]:[end]
  -v, --verbose           Use more verbose output
  -i, --indicate-current  Indicate current version (Alembic 0.9.9 or greater
                          is required)
  --help                  Show this message and exit.
```

*  with `--indicate-current`
```
$ FLASK_APP=app.py flask db history -i
bc9874116395 -> 6dd1d5ec3dde (head), empty message
387f936c6387 -> bc9874116395 (current), empty message
<base> -> 387f936c6387, empty message
```
`(current)` is the sign for current version.


Please review or comment if you could.
And feel free for editing my code.
Thank you for reading.
