### PR TITLE
Fix unreachable link to flask-sqlalchemy/binds

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,7 +110,7 @@ Multiple configuration callbacks can be defined simply by decorating multiple fu
 Multiple Database Support
 -------------------------
 
-Flask-Migrate can integrate with the  `binds <https://pythonhosted.org/Flask-SQLAlchemy/binds.html>`_ feature of Flask-SQLAlchemy, making it possible to track migrations to multiple databases associated with an application.
+Flask-Migrate can integrate with the  `binds <http://flask-sqlalchemy.pocoo.org/binds/>`_ feature of Flask-SQLAlchemy, making it possible to track migrations to multiple databases associated with an application.
 
 To create a multiple database migration repository, add the ``--multidb`` argument to the ``init`` command::
 
@@ -142,7 +142,7 @@ After the extension is initialized, a ``db`` group will be added to the command-
     Shows a list of available commands.
     
 - ``flask db init [--multidb]``
-    Initializes migration support for the application. The optional ``--multidb`` enables migrations for multiple databases configured as `Flask-SQLAlchemy binds <https://pythonhosted.org/Flask-SQLAlchemy/binds.html>`_.
+    Initializes migration support for the application. The optional ``--multidb`` enables migrations for multiple databases configured as `Flask-SQLAlchemy binds <http://flask-sqlalchemy.pocoo.org/binds/>`_.
     
 - ``flask db revision [--message MESSAGE] [--autogenerate] [--sql] [--head HEAD] [--splice] [--branch-label BRANCH_LABEL] [--version-path VERSION_PATH] [--rev-id REV_ID]``
     Creates an empty revision script. The script needs to be edited manually with the upgrade and downgrade changes. See `Alembic's documentation <http://alembic.zzzcomputing.com/en/latest/index.html>`_ for instructions on how to write migration scripts. An optional migration message can be included.


### PR DESCRIPTION
The original link redirects to flask-sqlalchemy.pocoo.org
Addressing it directly works and redirects to the latest version of flask-sqlalchemy