### PR TITLE
Add "Insert Seed Data" Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tests/temp_folder
 .mr.developer.cfg
 .project
 .pydevproject
+venv/

--- a/flask_migrate/cli.py
+++ b/flask_migrate/cli.py
@@ -13,6 +13,7 @@ from flask_migrate import heads as _heads
 from flask_migrate import branches as _branches
 from flask_migrate import current as _current
 from flask_migrate import stamp as _stamp
+from flask_migrate import seed as _seed
 
 @click.group()
 def db():
@@ -224,3 +225,10 @@ def stamp(directory, sql, tag, revision):
     """'stamp' the revision table with the given revision; don't run any
     migrations"""
     _stamp(directory, revision, sql, tag)
+
+
+@db.command()
+@with_appcontext
+def seed():
+    """'seed' inserts/update/removes seed data if defined"""
+    _seed()

--- a/tests/app_with_seed.py
+++ b/tests/app_with_seed.py
@@ -1,0 +1,32 @@
+#!/bin/env python
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_script import Manager
+from flask_migrate import Migrate, MigrateCommand
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+def customSeed():
+    seed_user = User('Alireza Ayinmehr')
+    db.session.add(seed_user)
+    db.session.commit()
+
+migrate = Migrate(app, db, seed=customSeed)
+
+manager = Manager(app)
+manager.add_command('db', MigrateCommand)
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128))
+
+    def __init__(self, name):
+        self.name = name
+
+if __name__ == '__main__':
+    manager.run()


### PR DESCRIPTION
Add a feature which let's the user give migrate object a function as seed with SQL operations in it, whenever user runs `flask db seed`, it runs that function and inserts the seed data

Alembic didn't have any command for inserting seed data, so I had to code it in Python