### PR TITLE
Fix '__version__' file not found in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.md LICENSE flask_migrate/templates/flask/* \
+include __version__ README.md LICENSE flask_migrate/templates/flask/* \
 flask_migrate/templates/flask-multidb/* tests/*
 


### PR DESCRIPTION
```Python-traceback
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    VERSION = open('__version__').read()
FileNotFoundError: [Errno 2] No such file or directory: '__version__'
```