### PR TITLE
allow `Path` objects to be used as `directory` parameter

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -43,14 +43,14 @@ class Migrate(object):
     def __init__(self, app=None, db=None, directory='migrations', **kwargs):
         self.configure_callbacks = []
         self.db = db
-        self.directory = directory
+        self.directory = str(directory)
         self.alembic_ctx_kwargs = kwargs
         if app is not None and db is not None:
             self.init_app(app, db, directory)
 
     def init_app(self, app, db=None, directory=None, **kwargs):
         self.db = db or self.db
-        self.directory = directory or self.directory
+        self.directory = str(directory or self.directory)
         self.alembic_ctx_kwargs.update(kwargs)
         if not hasattr(app, 'extensions'):
             app.extensions = {}
@@ -69,6 +69,7 @@ class Migrate(object):
     def get_config(self, directory=None, x_arg=None, opts=None):
         if directory is None:
             directory = self.directory
+        directory = str(directory)
         config = Config(os.path.join(directory, 'alembic.ini'))
         config.set_main_option('script_location', directory)
         if config.cmd_opts is None:

--- a/tests/app_custom_directory_path.py
+++ b/tests/app_custom_directory_path.py
@@ -1,0 +1,30 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_script import Manager
+from flask_migrate import Migrate, MigrateCommand
+from pathlib import Path
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+migrate = Migrate(app, db, directory=Path('temp_folder/temp_migrations'))
+
+manager = Manager(app)
+manager.add_command('db', MigrateCommand)
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128))
+
+
+@manager.command
+def add():
+    db.session.add(User(name='test'))
+    db.session.commit()
+
+
+if __name__ == '__main__':
+    manager.run()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -73,6 +73,16 @@ class TestMigrate(unittest.TestCase):
         (o, e, s) = run_cmd(sys.executable + ' app_custom_directory.py add')
         self.assertTrue(s == 0)
 
+    def test_custom_directory_path(self):
+        (o, e, s) = run_cmd(sys.executable + ' app_custom_directory_path.py db init')
+        self.assertTrue(s == 0)
+        (o, e, s) = run_cmd(sys.executable + ' app_custom_directory_path.py db migrate')
+        self.assertTrue(s == 0)
+        (o, e, s) = run_cmd(sys.executable + ' app_custom_directory_path.py db upgrade')
+        self.assertTrue(s == 0)
+        (o, e, s) = run_cmd(sys.executable + ' app_custom_directory_path.py add')
+        self.assertTrue(s == 0)
+
     def test_compare_type(self):
         (o, e, s) = run_cmd(sys.executable + ' app_compare_type1.py db init')
         self.assertTrue(s == 0)

--- a/tests/test_migrate_flaskcli.py
+++ b/tests/test_migrate_flaskcli.py
@@ -77,6 +77,18 @@ class TestMigrate(unittest.TestCase):
         db.session.add(User(name='test'))
         db.session.commit()
 
+    def test_custom_directory_path(self):
+        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db init')
+        self.assertTrue(s == 0)
+        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db migrate')
+        self.assertTrue(s == 0)
+        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db upgrade')
+        self.assertTrue(s == 0)
+
+        from .app_custom_directory_path import db, User
+        db.session.add(User(name='test'))
+        db.session.commit()
+
     def test_compare_type(self):
         (o, e, s) = run_cmd('app_compare_type1.py', 'flask db init')
         self.assertTrue(s == 0)


### PR DESCRIPTION
Generally, I'm copying the tests for `app_custom_directory` and also run them with a `Path` object. Is there a way to avoid the code duplication? For the test, we could use a parameterized test, but for the actual `app_custom_directory_path.py` file I don't see a good way, yet.

Fixes #318.