### PR TITLE
Update flask env.py template: relocate import statement

### DIFF
--- a/flask_migrate/templates/flask/env.py
+++ b/flask_migrate/templates/flask/env.py
@@ -5,6 +5,7 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
+from flask import current_app
 
 from alembic import context
 
@@ -21,7 +22,6 @@ logger = logging.getLogger('alembic.env')
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from flask import current_app
 config.set_main_option(
     'sqlalchemy.url',
     str(current_app.extensions['migrate'].db.engine.url).replace('%', '%%'))


### PR DESCRIPTION
This minor change mirrors a change applied to the multi-db version of `env.py` in https://github.com/miguelgrinberg/Flask-Migrate/commit/2a1ae1b9aa62c246fca2b2f1566284de8d4b940b#diff-30094d32b4f7e4cc7b46cb7d05fc03eeL22.

Moving this import to the top of the file helps remove style check warnings related to module-level imports (i.e. [`E402`](https://www.flake8rules.com/rules/E402.html) from `flake8`).