### PR TITLE
added name to logging.getLogger in __init__.py

### DIFF
--- a/flask_migrate/__init__.py
+++ b/flask_migrate/__init__.py
@@ -14,7 +14,7 @@ from alembic import command
 from alembic.util import CommandError
 
 alembic_version = tuple([int(v) for v in __alembic_version__.split('.')[0:3]])
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class _MigrateConfig(object):


### PR DESCRIPTION
Added dunder name to logging.getLogger() call to not clash with other application logging configurations