### PR TITLE
fix Sphinx warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Sphinx issues a warning, when the `html_static_path` contains paths with
underscores.

`tox -e docs` resulted in the following warning:
"WARNING: html_static_path entry '_static' does not exist"

As `_static` is the default value for `html_static_path` there is no
need to configure it explicitly.

Also see https://github.com/readthedocs/readthedocs.org/issues/1776

An alternative approach would have been to set the path to e.g.
`static`.