### PR TITLE
remove obsolete dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands=
 
 [testenv:flake8]
 deps=
-    six
     flake8
 commands=
     flake8 --exclude=".*" flask_migrate tests


### PR DESCRIPTION
`six` is not necessary to run `flake8`.