### PR TITLE
use unittest testrunner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,11 @@ setup(
         'Flask-SQLAlchemy>=1.0',
         'alembic>=0.7'
     ],
-    tests_require=[
-        'Flask-Script>=0.6'
-    ],
     entry_points={
         'flask.commands': [
             'db=flask_migrate.cli:db'
         ],
     },
-    test_suite="tests",
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 deps=
     flask-script
 commands=
-    python setup.py test
+    python -m unittest discover
 
 [testenv:flake8]
 deps=


### PR DESCRIPTION
... instead the deprecated `python setup.py tests`.

The latter one issued the following warning:

"WARNING: Testing via this command is deprecated and will be removed in
a future version. Users looking for a generic test entry point
independent of test runner are encouraged to use tox."

Another plus is that both the unittest runner and pytest also show
deprecation warnings, which `python setup.py tests` does not.