### PR TITLE
Strip version to avoid newline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ SQLAlchemy database migrations for Flask applications using Alembic.
 from setuptools import setup
 
 
-VERSION = open('__version__').read()
+VERSION = open('__version__').read().strip()
 
 setup(
     name='Flask-Migrate',


### PR DESCRIPTION
Strip version read from the file to avoid mistakenly including newline
in the version string.  This fixes the following warning:

    /usr/lib/python3.9/site-packages/setuptools/dist.py:484: UserWarning: Normalizing '3.0.2dev
    ' to '3.0.2.dev0'