### PR TITLE
add support for autoincrementing numerical version numbers

### DIFF
--- a/src/flask_migrate/cli.py
+++ b/src/flask_migrate/cli.py
@@ -24,14 +24,15 @@ def db(ctx):
     def get_next_migration_version():
         app = ctx.obj.load_app()
         migrate = app.extensions['migrate']
-        version_table = migrate.configure_args.get('version_table', 'alembic_version')
+        version_table = migrate.configure_args.get('version_table',
+                                                   'alembic_version')
 
         try:
             current_migration_version = int(migrate.db.engine.execute(
                 f"SELECT version_num FROM {version_table};"
             ).first()[0])
         except (DatabaseError, TypeError):
-            # database has no alembic_version table yet (or no current version row)
+            # database has no alembic_version table (or no version_num row)
             # this is the first migration
             return '0001'
         except ValueError:
@@ -42,9 +43,10 @@ def db(ctx):
         return f'{current_migration_version + 1:04}'
 
     default_map = ctx.default_map or {}
-    for cmd_name in ('merge', 'migrate', 'revision'):
-        default_map.setdefault(cmd_name, {})['rev_id'] = get_next_migration_version
+    for cmd in ('merge', 'migrate', 'revision'):
+        default_map.setdefault(cmd, {})['rev_id'] = get_next_migration_version
     ctx.default_map = default_map
+
 
 @db.command()
 @with_appcontext

--- a/tests/app_multidb_2.py
+++ b/tests/app_multidb_2.py
@@ -1,0 +1,30 @@
+#!/bin/env python
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app1.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_BINDS'] = {
+    "db1": "sqlite:///app2.db",
+}
+
+db = SQLAlchemy(app)
+migrate = Migrate(app, db)
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128))
+    bio = db.Column(db.Text)
+
+
+class Group(db.Model):
+    __bind_key__ = 'db1'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128))
+
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -93,7 +93,8 @@ class TestMigrate(unittest.TestCase):
     def test_compare_type(self):
         (o, e, s) = run_cmd('app_compare_type1.py', 'flask db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type1.py', 'flask db migrate -m "create models"')
+        (o, e, s) = run_cmd('app_compare_type1.py',
+                            'flask db migrate -m "create models"')
         self.assertTrue(s == 0)
         self.assertTrue(b'0001_create_models.py' in o)
         (o, e, s) = run_cmd('app_compare_type1.py', 'flask db upgrade')

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -56,8 +56,9 @@ class TestMigrate(unittest.TestCase):
     def test_migrate_upgrade(self):
         (o, e, s) = run_cmd('app.py', 'flask db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app.py', 'flask db migrate')
+        (o, e, s) = run_cmd('app.py', 'flask db migrate -m "create models"')
         self.assertTrue(s == 0)
+        self.assertTrue(b'0001_create_models.py' in o)
         (o, e, s) = run_cmd('app.py', 'flask db upgrade')
         self.assertTrue(s == 0)
 
@@ -92,11 +93,14 @@ class TestMigrate(unittest.TestCase):
     def test_compare_type(self):
         (o, e, s) = run_cmd('app_compare_type1.py', 'flask db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type1.py', 'flask db migrate')
+        (o, e, s) = run_cmd('app_compare_type1.py', 'flask db migrate -m "create models"')
         self.assertTrue(s == 0)
+        self.assertTrue(b'0001_create_models.py' in o)
         (o, e, s) = run_cmd('app_compare_type1.py', 'flask db upgrade')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type2.py', 'flask db migrate')
+        (o, e, s) = run_cmd('app_compare_type2.py',
+                            'flask db migrate -m "shorten User name column"')
         self.assertTrue(s == 0)
+        self.assertTrue(b'0002_shorten_user_name_column.py' in o)
         self.assertTrue(b'Detected type change from VARCHAR(length=128) '
                         b'to String(length=10)' in e)

--- a/tests/test_multidb_migrate.py
+++ b/tests/test_multidb_migrate.py
@@ -83,22 +83,6 @@ class TestMigrate(unittest.TestCase):
                             'flask db migrate -m "add User bio column"')
         self.assertTrue(s == 0, e)
         self.assertTrue(b'0002_add_user_bio_column.py' in o)
-        (o, e, s) = run_cmd('app_multidb_2.py', 'flask db upgrade')
-        self.assertTrue(s == 0, e)
-
-        conn1 = sqlite3.connect('app1.db')
-        c = conn1.cursor()
-        c.execute('select version_num from alembic_version')
-        version_num = c.fetchone()
-        conn1.close()
-        self.assertTrue(version_num == ('0002',))
-
-        conn2 = sqlite3.connect('app2.db')
-        c = conn2.cursor()
-        c.execute('select version_num from alembic_version')
-        version_num = c.fetchone()
-        conn2.close()
-        self.assertTrue(version_num == ('0002',))
 
         # ensure the downgrade works
         (o, e, s) = run_cmd('app_multidb.py', 'flask db downgrade base')

--- a/tests/test_multidb_migrate.py
+++ b/tests/test_multidb_migrate.py
@@ -42,7 +42,8 @@ class TestMigrate(unittest.TestCase):
     def test_multidb_migrate_upgrade(self):
         (o, e, s) = run_cmd('app_multidb.py', 'flask db init --multidb')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_multidb.py', 'flask db migrate -m "create models"')
+        (o, e, s) = run_cmd('app_multidb.py',
+                            'flask db migrate -m "create models"')
         self.assertTrue(s == 0)
         self.assertTrue(b'0001_create_models.py' in o)
         (o, e, s) = run_cmd('app_multidb.py', 'flask db upgrade')
@@ -101,7 +102,7 @@ class TestMigrate(unittest.TestCase):
 
         # ensure the downgrade works
         (o, e, s) = run_cmd('app_multidb.py', 'flask db downgrade base')
-        self.assertTrue(s == 0)
+        self.assertTrue(s == 0, e)
 
         conn1 = sqlite3.connect('app1.db')
         c = conn1.cursor()


### PR DESCRIPTION
This PR changes the default behavior of autogenerated migration version numbers, from using UUID strings to sequential numbers (eg 0001 -> 0002 -> 0003). Backwards compatibility is maintained for existing projects using UUIDs (behavior is unchanged), while new projects will default to the new behavior.