### PR TITLE
Specify license in project metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = Flask-Migrate
 version = 3.1.1.dev0
 author = Miguel Grinberg
 author_email = miguel.grinberg@gmail.com
+license = MIT
 description = SQLAlchemy database migrations for Flask applications using Alembic.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
I've used "MIT" so it is directly parsable as an SPDX license expression.

This makes it easier for downstream to users to get the license information directly from the package metadata.