### PR TITLE
Fix running tests in venv with --system-site-packages

### DIFF
--- a/tests/test_custom_template.py
+++ b/tests/test_custom_template.py
@@ -3,12 +3,16 @@ import shutil
 import unittest
 import subprocess
 import shlex
+import sys
 
 
-def run_cmd(app, cmd):
-    """Run a command and return a tuple with (stdout, stderr, exit_code)"""
+def run_flask(app, cmd):
+    """
+    Run a flask command and return a tuple with (stdout, stderr, exit_code)
+    """
     os.environ['FLASK_APP'] = app
-    process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+    process = subprocess.Popen([sys.executable, '-m', 'flask'] +
+                               shlex.split(cmd), stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     (stdout, stderr) = process.communicate()
     print('\n$ ' + cmd)
@@ -54,11 +58,11 @@ class TestMigrate(unittest.TestCase):
             self.assertTrue(isinstance(v, int))
 
     def test_migrate_upgrade(self):
-        (o, e, s) = run_cmd('app.py', 'flask db init -t ./custom_template')
+        (o, e, s) = run_flask('app.py', 'db init -t ./custom_template')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app.py', 'flask db migrate')
+        (o, e, s) = run_flask('app.py', 'db migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app.py', 'flask db upgrade')
+        (o, e, s) = run_flask('app.py', 'db upgrade')
         self.assertTrue(s == 0)
 
         from .app import app, db, User

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -3,12 +3,16 @@ import shutil
 import unittest
 import subprocess
 import shlex
+import sys
 
 
-def run_cmd(app, cmd):
-    """Run a command and return a tuple with (stdout, stderr, exit_code)"""
+def run_flask(app, cmd):
+    """
+    Run a flask command and return a tuple with (stdout, stderr, exit_code)
+    """
     os.environ['FLASK_APP'] = app
-    process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+    process = subprocess.Popen([sys.executable, '-m', 'flask'] +
+                               shlex.split(cmd), stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     (stdout, stderr) = process.communicate()
     print('\n$ ' + cmd)
@@ -54,11 +58,11 @@ class TestMigrate(unittest.TestCase):
             self.assertTrue(isinstance(v, int))
 
     def test_migrate_upgrade(self):
-        (o, e, s) = run_cmd('app.py', 'flask db init')
+        (o, e, s) = run_flask('app.py', 'db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app.py', 'flask db migrate')
+        (o, e, s) = run_flask('app.py', 'db migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app.py', 'flask db upgrade')
+        (o, e, s) = run_flask('app.py', 'db upgrade')
         self.assertTrue(s == 0)
 
         from .app import app, db, User
@@ -67,11 +71,11 @@ class TestMigrate(unittest.TestCase):
             db.session.commit()
 
     def test_custom_directory(self):
-        (o, e, s) = run_cmd('app_custom_directory.py', 'flask db init')
+        (o, e, s) = run_flask('app_custom_directory.py', 'db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_custom_directory.py', 'flask db migrate')
+        (o, e, s) = run_flask('app_custom_directory.py', 'db migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_custom_directory.py', 'flask db upgrade')
+        (o, e, s) = run_flask('app_custom_directory.py', 'db upgrade')
         self.assertTrue(s == 0)
 
         from .app_custom_directory import app, db, User
@@ -80,11 +84,11 @@ class TestMigrate(unittest.TestCase):
             db.session.commit()
 
     def test_custom_directory_path(self):
-        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db init')
+        (o, e, s) = run_flask('app_custom_directory_path.py', 'db init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db migrate')
+        (o, e, s) = run_flask('app_custom_directory_path.py', 'db migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_custom_directory_path.py', 'flask db upgrade')
+        (o, e, s) = run_flask('app_custom_directory_path.py', 'db upgrade')
         self.assertTrue(s == 0)
 
         from .app_custom_directory_path import app, db, User
@@ -93,13 +97,13 @@ class TestMigrate(unittest.TestCase):
             db.session.commit()
 
     def test_compare_type(self):
-        (o, e, s) = run_cmd('app_compare_type1.py', 'flask database init')
+        (o, e, s) = run_flask('app_compare_type1.py', 'database init')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type1.py', 'flask database migrate')
+        (o, e, s) = run_flask('app_compare_type1.py', 'database migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type1.py', 'flask database upgrade')
+        (o, e, s) = run_flask('app_compare_type1.py', 'database upgrade')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_compare_type2.py', 'flask database migrate')
+        (o, e, s) = run_flask('app_compare_type2.py', 'database migrate')
         self.assertTrue(s == 0)
         self.assertTrue(b'Detected type change from VARCHAR(length=128) '
                         b'to String(length=10)' in e)

--- a/tests/test_multidb_migrate.py
+++ b/tests/test_multidb_migrate.py
@@ -4,12 +4,16 @@ import unittest
 import subprocess
 import shlex
 import sqlite3
+import sys
 
 
-def run_cmd(app, cmd):
-    """Run a command and return a tuple with (stdout, stderr, exit_code)"""
+def run_flask(app, cmd):
+    """
+    Run a flask command and return a tuple with (stdout, stderr, exit_code)
+    """
     os.environ['FLASK_APP'] = app
-    process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,
+    process = subprocess.Popen([sys.executable, '-m', 'flask'] +
+                               shlex.split(cmd), stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     (stdout, stderr) = process.communicate()
     print('\n$ ' + cmd)
@@ -43,11 +47,11 @@ class TestMigrate(unittest.TestCase):
             pass
 
     def test_multidb_migrate_upgrade(self):
-        (o, e, s) = run_cmd('app_multidb.py', 'flask db init --multidb')
+        (o, e, s) = run_flask('app_multidb.py', 'db init --multidb')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_multidb.py', 'flask db migrate')
+        (o, e, s) = run_flask('app_multidb.py', 'db migrate')
         self.assertTrue(s == 0)
-        (o, e, s) = run_cmd('app_multidb.py', 'flask db upgrade')
+        (o, e, s) = run_flask('app_multidb.py', 'db upgrade')
         self.assertTrue(s == 0)
 
         # ensure the tables are in the correct databases
@@ -75,7 +79,7 @@ class TestMigrate(unittest.TestCase):
             db.session.commit()
 
         # ensure the downgrade works
-        (o, e, s) = run_cmd('app_multidb.py', 'flask db downgrade')
+        (o, e, s) = run_flask('app_multidb.py', 'db downgrade')
         self.assertTrue(s == 0)
 
         conn1 = sqlite3.connect('app1.db')


### PR DESCRIPTION
Ensure that flask is run via `python -m flask` rather than `flask`. This is necessary to fix running the test suite when flask_migrate is installed into a venv created with `--system-site-packages` and flask itself is installed into the system site-packages directory.  This is the scenario we are using in Gentoo to test packages prior to them being installed.  Calling flask directly is a problem because it forces `/usr/bin/pythonX.Y` and therefore omits the venv `sys.path` logic.