### PR TITLE
Fix issues spotted by isort and pyupgrade

### DIFF
--- a/src/flask_migrate/templates/aioflask-multidb/env.py
+++ b/src/flask_migrate/templates/aioflask-multidb/env.py
@@ -1,13 +1,10 @@
-from __future__ import with_statement
-
 import asyncio
 import logging
 from logging.config import fileConfig
 
-from sqlalchemy import MetaData
-from flask import current_app
-
 from alembic import context
+from flask import current_app
+from sqlalchemy import MetaData
 
 USE_TWOPHASE = False
 

--- a/src/flask_migrate/templates/aioflask/env.py
+++ b/src/flask_migrate/templates/aioflask/env.py
@@ -1,12 +1,9 @@
-from __future__ import with_statement
-
 import asyncio
 import logging
 from logging.config import fileConfig
 
-from flask import current_app
-
 from alembic import context
+from flask import current_app
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/src/flask_migrate/templates/flask-multidb/env.py
+++ b/src/flask_migrate/templates/flask-multidb/env.py
@@ -1,12 +1,9 @@
-from __future__ import with_statement
-
 import logging
 from logging.config import fileConfig
 
-from sqlalchemy import MetaData
-from flask import current_app
-
 from alembic import context
+from flask import current_app
+from sqlalchemy import MetaData
 
 USE_TWOPHASE = False
 

--- a/src/flask_migrate/templates/flask/env.py
+++ b/src/flask_migrate/templates/flask/env.py
@@ -1,11 +1,8 @@
-from __future__ import with_statement
-
 import logging
 from logging.config import fileConfig
 
-from flask import current_app
-
 from alembic import context
+from flask import current_app
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/tests/custom_template/env.py
+++ b/tests/custom_template/env.py
@@ -1,12 +1,10 @@
 # Custom template
-from __future__ import with_statement
 
 import logging
 from logging.config import fileConfig
 
-from flask import current_app
-
 from alembic import context
+from flask import current_app
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
After using Flask-Migrate to create a migrations folder, I ran `isort` and `pyupgrade` (via [ruff](https://github.com/charliermarsh/ruff#configuration)), and it pointed out two issues with the env.py file:

1. The `from __future__ import with_statement` line isn't needed for Python 2.7+, Alembic core got rid of it a few years of ago: https://github.com/sqlalchemy/alembic/pull/544
2. The imports aren't sorted alphabetically. Not a big deal, but since lots of devs do run isort on their code, I thought I may as well change that while I was here. I can revert that part if you'd like.