### PR TITLE
Fix SQLAlchemy v2 compatibilty issue

### DIFF
--- a/src/flask_migrate/templates/flask/env.py
+++ b/src/flask_migrate/templates/flask/env.py
@@ -29,7 +29,7 @@ def get_engine():
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 config.set_main_option(
-    'sqlalchemy.url', str(get_engine().url).replace('%', '%%'))
+    'sqlalchemy.url', str(get_engine().url.render_as_string(hide_password=False)).replace('%', '%%'))
 target_db = current_app.extensions['migrate'].db
 
 # other values from the config, defined by the needs of env.py,

--- a/src/flask_migrate/templates/flask/env.py
+++ b/src/flask_migrate/templates/flask/env.py
@@ -29,7 +29,11 @@ def get_engine():
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 config.set_main_option(
-    'sqlalchemy.url', str(get_engine().url.render_as_string(hide_password=False)).replace('%', '%%'))
+    "sqlalchemy.url",
+    str(
+        current_app.extensions["migrate"].db.engine.url.render_as_string(hide_password=False)
+    ).replace("%", "%%"),
+)
 target_db = current_app.extensions['migrate'].db
 
 # other values from the config, defined by the needs of env.py,

--- a/src/flask_migrate/templates/flask/env.py
+++ b/src/flask_migrate/templates/flask/env.py
@@ -30,9 +30,7 @@ def get_engine():
 # target_metadata = mymodel.Base.metadata
 config.set_main_option(
     "sqlalchemy.url",
-    str(
-        current_app.extensions["migrate"].db.engine.url.render_as_string(hide_password=False)
-    ).replace("%", "%%"),
+    str(get_engine().url.render_as_string(hide_password=False)).replace("%", "%%"),
 )
 target_db = current_app.extensions['migrate'].db
 


### PR DESCRIPTION
Hi,

Following the issue that I created in the SQLAlchemy repo, we identified that the bug came from Flask-migrate.

With SQLAlchemy v2, engine url has a obfuscate password like that : 

`'sqlalchemy.url': 'postgresql://user:***@HOST:PORT/db-name'`

So, when we execute flask db upgrade, it will not be able to connect to db and then raise password authentication error.
That's why, I made a quick fix respecting the doc of sqlalchemy v2.

Here is the discussion I had with the maintainers of SQLAlchemy : https://github.com/sqlalchemy/sqlalchemy/discussions/9225#discussioncomment-4854042

Here is the issue created on your repo : https://github.com/miguelgrinberg/Flask-Migrate/issues/505

Thanks a lot !