### PR TITLE
catch `AttributeError` instead of `TypeError`

### DIFF
--- a/src/flask_migrate/templates/aioflask-multidb/env.py
+++ b/src/flask_migrate/templates/aioflask-multidb/env.py
@@ -23,7 +23,7 @@ def get_engine(bind_key=None):
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions['migrate'].db.get_engine(bind=bind_key)
-    except TypeError:
+    except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
         return current_app.extensions['migrate'].db.engines.get(bind_key)
 

--- a/src/flask_migrate/templates/aioflask/env.py
+++ b/src/flask_migrate/templates/aioflask/env.py
@@ -20,7 +20,7 @@ def get_engine():
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions['migrate'].db.get_engine()
-    except TypeError:
+    except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
         return current_app.extensions['migrate'].db.engine
 

--- a/src/flask_migrate/templates/flask-multidb/env.py
+++ b/src/flask_migrate/templates/flask-multidb/env.py
@@ -22,7 +22,7 @@ def get_engine(bind_key=None):
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions['migrate'].db.get_engine(bind=bind_key)
-    except TypeError:
+    except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
         return current_app.extensions['migrate'].db.engines.get(bind_key)
 

--- a/src/flask_migrate/templates/flask/env.py
+++ b/src/flask_migrate/templates/flask/env.py
@@ -19,7 +19,7 @@ def get_engine():
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions['migrate'].db.get_engine()
-    except TypeError:
+    except (TypeError, AttributeError):
         # this works with Flask-SQLAlchemy>=3
         return current_app.extensions['migrate'].db.engine
 


### PR DESCRIPTION
In Flask-SQLAlchemy 3.1, the deprecated `get_engine` method will be removed, after raising a `DeprecationWarning` in 3.0. https://github.com/miguelgrinberg/Flask-Migrate/commit/7cb4236327ea04fc6be8a17bbfadae6de7bfbc8b caught `TypeError`, but a method that doesn't exist raises an `AttributeError`.