### PR TITLE
Add --purge flag to the stamp command

### DIFF
--- a/src/flask_migrate/__init__.py
+++ b/src/flask_migrate/__init__.py
@@ -252,11 +252,11 @@ def current(directory=None, verbose=False):
 
 
 @catch_errors
-def stamp(directory=None, revision='head', sql=False, tag=None):
+def stamp(directory=None, revision='head', sql=False, tag=None, purge=False):
     """'stamp' the revision table with the given revision; don't run any
     migrations"""
     config = current_app.extensions['migrate'].migrate.get_config(directory)
-    command.stamp(config, revision, sql=sql, tag=tag)
+    command.stamp(config, revision, sql=sql, tag=tag, purge=purge)
 
 
 @catch_errors

--- a/src/flask_migrate/cli.py
+++ b/src/flask_migrate/cli.py
@@ -238,12 +238,15 @@ def current(directory, verbose):
 @click.option('--tag', default=None,
               help=('Arbitrary "tag" name - can be used by custom env.py '
                     'scripts'))
+@click.option('--purge', is_flag=True,
+              help=('Delete the version in the alembic_version table before '
+                    'stamping'))
 @click.argument('revision', default='head')
 @with_appcontext
-def stamp(directory, sql, tag, revision):
+def stamp(directory, sql, tag, revision, purge):
     """'stamp' the revision table with the given revision; don't run any
     migrations"""
-    _stamp(directory, revision, sql, tag)
+    _stamp(directory, revision, sql, tag, purge)
 
 
 @db.command()


### PR DESCRIPTION
When running migrations, I've occasionally encountered an issue where the database is at a revision that is no longer exists due to a change in the structure of the migrations. When this is the case, it would be useful to be able to purge the revision present in the `alembic_version` table and stamp the new revision ID that corresponds to the database's current state.

Alembic already contains this capability, so I've just added it into the flask-migrate `stamp` command.