### PR TITLE
Check g.x_arg exists before working on it

### DIFF
--- a/src/flask_migrate/__init__.py
+++ b/src/flask_migrate/__init__.py
@@ -93,7 +93,7 @@ class Migrate(object):
             setattr(config.cmd_opts, opt, True)
         if not hasattr(config.cmd_opts, 'x'):
             setattr(config.cmd_opts, 'x', [])
-            for x in g.x_arg:
+            for x in getattr(g, 'x_arg', []):
                 config.cmd_opts.x.append(x)
             if x_arg is not None:
                 if isinstance(x_arg, list) or isinstance(x_arg, tuple):


### PR DESCRIPTION
If `g.x_arg` doesn't exist Flask-Migrate fails with an uncaught attribute error. Use getattr to avoid this.