### PR TITLE
Added missing option x_args to commands that lacks it

### DIFF
--- a/src/flask_migrate/__init__.py
+++ b/src/flask_migrate/__init__.py
@@ -252,15 +252,15 @@ def current(directory=None, verbose=False):
 
 
 @catch_errors
-def stamp(directory=None, revision='head', sql=False, tag=None, purge=False):
+def stamp(directory=None, revision='head', sql=False, tag=None, purge=False, x_arg=None):
     """'stamp' the revision table with the given revision; don't run any
     migrations"""
-    config = current_app.extensions['migrate'].migrate.get_config(directory)
+    config = current_app.extensions['migrate'].migrate.get_config(directory, x_arg=x_arg)
     command.stamp(config, revision, sql=sql, tag=tag, purge=purge)
 
 
 @catch_errors
-def check(directory=None):
+def check(directory=None, x_arg=None):
     """Check if there are any new operations to migrate"""
-    config = current_app.extensions['migrate'].migrate.get_config(directory)
+    config = current_app.extensions['migrate'].migrate.get_config(directory, x_arg)
     command.check(config)

--- a/src/flask_migrate/cli.py
+++ b/src/flask_migrate/cli.py
@@ -241,18 +241,22 @@ def current(directory, verbose):
 @click.option('--purge', is_flag=True,
               help=('Delete the version in the alembic_version table before '
                     'stamping'))
+@click.option('-x', '--x-arg', multiple=True,
+              help='Additional arguments consumed by custom env.py scripts')
 @click.argument('revision', default='head')
 @with_appcontext
-def stamp(directory, sql, tag, revision, purge):
+def stamp(directory, sql, tag, revision, purge, x_arg):
     """'stamp' the revision table with the given revision; don't run any
     migrations"""
-    _stamp(directory, revision, sql, tag, purge)
+    _stamp(directory, revision, sql, tag, purge, x_arg)
 
 
 @db.command()
 @click.option('-d', '--directory', default=None,
               help=('Migration script directory (default is "migrations")'))
+@click.option('-x', '--x-arg', multiple=True,
+              help='Additional arguments consumed by custom env.py scripts')
 @with_appcontext
-def check(directory):
+def check(directory, x_arg):
     """Check if there are any new operations to migrate"""
-    _check(directory)
+    _check(directory, x_arg)


### PR DESCRIPTION
Reading the documentation i read that the argument `--x-arg` should be available for every command, just like `--directory`. 

But i found out that this is not the case, in fact it is missing on:

- check
- stamp

and many others. Those two are the ones i need for my application at the moment

The solution i used is simple and based on the other commands. Let me know if it will be useful that i do the same for the other commands